### PR TITLE
Remove line counter from end of CSV

### DIFF
--- a/queries.sh
+++ b/queries.sh
@@ -126,4 +126,7 @@ else
     psql -h $HOST -p $PORT -d $DATABASE --user=$USER -A -F ',' -f $INPUT -o $OUTPUT $TUPLE_ONLY
 fi
 
+# Remove line counter from end of CSV
+sed -i '' -e '$ d' $OUTPUT
+
 exit 0


### PR DESCRIPTION
Redshift includes a count of the number of result rows at the end of the output - this needs to be removed for the CSV to validate correctly
